### PR TITLE
Get event start time during event creation

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ mysqlclient = "==1.3.12"
 yarl = "<1.2"
 "discord.py" = {editable = true, ref = "6b75179c1fed1aac0304526d130e93ad21dc84c3", git = "git://github.com/rapptz/discord.py.git"}
 SQLAlchemy = "==1.2.8"
+arrow = "==0.10.0"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d1c247db417613eb23bc8f8cc106ce4168f7bf1ee9fa84c088fc4ecbb862bfca"
+            "sha256": "0da32197074261f7ec14c53812cd857b07e5107353f20af5940f3c70a850ae1a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -33,6 +33,13 @@
                 "sha256:f0e2ac69cb709367400008cebccd5d48161dd146096a009a632a132babe5714c"
             ],
             "version": "==2.2.5"
+        },
+        "arrow": {
+            "hashes": [
+                "sha256:805906f09445afc1f0fc80187db8fe07670e3b25cdafa09b8d8ac264a8c0c722"
+            ],
+            "index": "pypi",
+            "version": "==0.10.0"
         },
         "async-timeout": {
             "hashes": [
@@ -77,6 +84,7 @@
                 "sha256:d870f399fcd58a1889e93008762a3b9a27cf7ea512818fc6e689f59495648355",
                 "sha256:e9404e2e19e901121c3c5c6cffd5a8ae0d1d67919c970e3b3262231175713068"
             ],
+            "markers": "python_version >= '3.4.1'",
             "version": "==4.3.1"
         },
         "mysqlclient": {
@@ -90,6 +98,13 @@
             "index": "pypi",
             "version": "==1.3.12"
         },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:1adb80e7a782c12e52ef9a8182bebeb73f1d7e24e374397af06fb4956c8dc5c0",
+                "sha256:e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8"
+            ],
+            "version": "==2.7.3"
+        },
         "python-dotenv": {
             "hashes": [
                 "sha256:4965ed170bf51c347a89820e8050655e9c25db3837db6602e906b6d850fad85c",
@@ -97,6 +112,13 @@
             ],
             "index": "pypi",
             "version": "==0.8.2"
+        },
+        "six": {
+            "hashes": [
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+            ],
+            "version": "==1.11.0"
         },
         "sqlalchemy": {
             "hashes": [

--- a/apollo/commands/event_command.py
+++ b/apollo/commands/event_command.py
@@ -3,6 +3,7 @@ from discord.ext import commands
 from apollo.list_events import list_events
 from apollo.models import Event, EventChannel, Guild
 from apollo.queries import find_or_create_guild, find_or_create_user
+from apollo.time_zones import VALID_TIME_ZONES
 
 
 class EventCommand:
@@ -61,6 +62,17 @@ class EventCommand:
             return EventChannel(id=channel.id, guild_id=ctx.guild.id)
 
 
+    async def _get_time_zone(self, ctx):
+        """Retrieve a valid time zone string from the user"""
+        await ctx.author.send("Enter your time zone:")
+        while True:
+            time_zone = (await self.bot.get_next_pm(ctx.author)).content.upper()
+            if time_zone in VALID_TIME_ZONES.keys():
+                return VALID_TIME_ZONES.get(time_zone)
+            else:
+                await ctx.author.send("Invalid time zone. Try again:")
+
+
     async def _get_title_from_user(self, ctx):
         """Retrieve the event title from the user"""
         await ctx.author.send("Enter the event title:")
@@ -80,4 +92,5 @@ class EventCommand:
         event.description = await self._get_desc_from_user(ctx)
         event.capacity = await self._get_capacity_from_user(ctx)
         event.event_channel = await self._get_event_channel(ctx)
+        event.time_zone = await self._get_time_zone(ctx)
         return event

--- a/apollo/models/event.py
+++ b/apollo/models/event.py
@@ -13,6 +13,7 @@ class Event(Base):
     title = Column(Text)
     description = Column(Text)
     start_time = Column(DateTime)
+    time_zone = Column(Text)
     capacity = Column(Integer)
     organizer = relationship("User", back_populates="events")
     responses = relationship("Response", passive_deletes=True)

--- a/apollo/time_zones.py
+++ b/apollo/time_zones.py
@@ -1,0 +1,3 @@
+VALID_TIME_ZONES = {
+    "PST" : "US/Pacific"
+}


### PR DESCRIPTION
This PR adds functionality for getting a the event start time, and storing it as UTC. We use the time zone string given by the user to do this conversion. We also save the time zone string so that we can easily convert back to the user's local time when it comes time to display the information.

The input accepts both 12 hour and 24 hour time formats. Spirit only allowed for 12 hour time format, which was often confusing to users.

**Demo**
![screenshot from 2018-07-29 13-04-04](https://user-images.githubusercontent.com/10660608/43370209-ea46b97c-932f-11e8-95f7-e0c5065ff154.png)
