### PR TITLE
Add automatic event reminders

### DIFF
--- a/apollo/embeds/__init__.py
+++ b/apollo/embeds/__init__.py
@@ -4,3 +4,4 @@ from .help_embed import HelpEmbed
 from .select_channel_embed import SelectChannelEmbed
 from .start_time_embed import StartTimeEmbed
 from .time_zone_embed import TimeZoneEmbed
+from .reminder_embed import ReminderEmbed

--- a/apollo/embeds/reminder_embed.py
+++ b/apollo/embeds/reminder_embed.py
@@ -1,0 +1,22 @@
+import discord
+
+from apollo.constants import EMBED_COLOR
+from apollo.translate import t
+
+
+class ReminderEmbed:
+    def call(self, event_title, start_time):
+        embed = discord.Embed()
+        embed.color = EMBED_COLOR
+        embed.title = t("reminder.title")
+        embed.description = self._event_summary(event_title, start_time)
+        return embed
+
+    def _event_summary(self, event_title, start_time):
+        start_time = self._formatted_start_time(start_time)
+        return f"{event_title} - {start_time}"
+
+    def _formatted_start_time(self, start_time):
+        time_display = start_time.format("h:mm A")
+        time_zone = start_time.tzname()
+        return f"{time_display} {time_zone}"

--- a/apollo/models/event.py
+++ b/apollo/models/event.py
@@ -30,3 +30,6 @@ class Event(Base):
     @property
     def utc_start_time(self):
         return arrow.get(self.start_time, "utc")
+
+    def localized_start_time(self, time_zone):
+        return self.utc_start_time.to(time_zone)

--- a/apollo/services/__init__.py
+++ b/apollo/services/__init__.py
@@ -7,3 +7,4 @@ from .send_channel_select import SendChannelSelect
 from .sync_event_channels import SyncEventChannels
 from .format_date_time import FormatDateTime
 from .request_local_start_time import RequestLocalStartTime
+from .send_event_reminders import SendEventReminders

--- a/apollo/services/send_event_reminders.py
+++ b/apollo/services/send_event_reminders.py
@@ -1,0 +1,34 @@
+from discord.errors import Forbidden
+
+from apollo.models import User, Response
+
+
+class SendEventReminders:
+    def __init__(self, bot, reminder_embed):
+        self.bot = bot
+        self.reminder_embed = reminder_embed
+
+    async def call(self, event):
+        with self.bot.scoped_session() as session:
+            apollo_users = (
+                session.query(User)
+                .join(Response)
+                .filter(Response.event_id == event.id)
+                .filter(Response.status == "accepted")
+                .all()
+            )
+
+        for apollo_user in apollo_users:
+            # If the user has set a time zone, let's make their life a bit easier
+            if apollo_user.time_zone:
+                start_time = event.localized_start_time(apollo_user.time_zone)
+            else:
+                start_time = event.local_start_time
+
+            embed = self.reminder_embed.call(event.title, start_time)
+            discord_user = self.bot.get_user(apollo_user.id)
+
+            try:
+                await discord_user.send(embed=embed)
+            except Forbidden:
+                pass

--- a/apollo/tasks/__init__.py
+++ b/apollo/tasks/__init__.py
@@ -1,1 +1,2 @@
 from .sync_discord_bots import SyncDiscordBots
+from .automatic_reminders import AutomaticReminders

--- a/apollo/tasks/automatic_reminders.py
+++ b/apollo/tasks/automatic_reminders.py
@@ -1,0 +1,35 @@
+import datetime
+
+from discord.ext import commands, tasks
+
+from apollo.models import Event
+
+REMINDER_PERIOD_MINUTES = 10
+
+
+class AutomaticReminders(commands.Cog):
+    def __init__(self, bot, send_event_reminders):
+        self.bot = bot
+        self.send_event_reminders = send_event_reminders
+        self.send_reminders.start()
+
+    @tasks.loop(seconds=60)
+    async def send_reminders(self):
+        current_time = datetime.datetime.now()
+
+        # We strip seconds so that our query will match exactly on event start times.
+        targetted_start_time = (
+            current_time + datetime.timedelta(minutes=REMINDER_PERIOD_MINUTES)
+        ).replace(second=0, microsecond=0)
+
+        with self.bot.scoped_session() as session:
+            events_starting_soon = (
+                session.query(Event).filter_by(start_time=targetted_start_time).all()
+            )
+
+        for event in events_starting_soon:
+            await self.send_event_reminders.call(event)
+
+    @send_reminders.before_loop
+    async def before_sending_reminders(self):
+        await self.bot.wait_until_ready()

--- a/app.py
+++ b/app.py
@@ -59,6 +59,7 @@ event_embed = EventEmbed()
 help_embed = HelpEmbed()
 start_time_embed = StartTimeEmbed()
 time_zone_embed = TimeZoneEmbed()
+reminder_embed = ReminderEmbed()
 
 # Initialize services
 format_date_time = FormatDateTime()
@@ -73,6 +74,7 @@ list_events = ListEvents(apollo, list_event)
 handle_event_reaction = HandleEventReaction(
     apollo, update_event, update_response, request_local_start_time
 )
+send_event_reminders = SendEventReminders(apollo, reminder_embed)
 
 # Add events
 apollo.add_cog(OnCommandError(apollo))
@@ -107,6 +109,7 @@ apollo.add_cog(TimeZoneCommand(apollo, time_zone_embed, time_zone_input))
 apollo.add_check(NotEventChannel(apollo))
 
 # Add tasks
+apollo.add_cog(AutomaticReminders(apollo, send_event_reminders))
 if env == "production":
     apollo.add_cog(SyncDiscordBots(apollo, dbl.Client(apollo, os.getenv("DBL_TOKEN"))))
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -78,6 +78,9 @@ role:
 
     To change this role, use: `{}role event <role>`
 
+reminder:
+  title: "REMINDER: Event starting soon!"
+
 select_channel:
   title:
     "Select an event channel:"


### PR DESCRIPTION
# Overview
We want to remind attendees that an event is about to start, similar to how Google calendar operates.

To start out with, the reminder will go out ~10 minutes before the event starts. Later on we can look at adding the option to either disable reminders, or to change the time at which reminders go out.

#### Reminder message
![image](https://user-images.githubusercontent.com/10660608/65742275-59f50900-e0a4-11e9-9a67-1519953dd2ea.png)
