### PR TITLE
Show accepted count regardless of capacity

### DIFF
--- a/apollo/embeds/event_embed.py
+++ b/apollo/embeds/event_embed.py
@@ -85,8 +85,13 @@ class EventEmbed:
 
     def _accepted_header(self, event_capacity, accepted_count):
         header = self.ACCEPTED_HEADER
+
         if event_capacity:
-            header += f" ({accepted_count}/{event_capacity})"
+            return f"{header} ({accepted_count}/{event_capacity})"
+
+        if accepted_count > 0:
+            return f"{header} ({accepted_count})"
+
         return header
 
     def _user_ids_to_members(self, user_ids, guild):


### PR DESCRIPTION
# Overview

Even if there isn't a set limit on the number of attendees, it's still
useful to see at a glance how many people have accepted the event.

**Trello card:** https://trello.com/c/IdCKcRTj/96-display-number-of-accepted-declined-tentative-and-standby-users

## Screenshots

### No capacity

| No accepted users | With accepted users |
| - | - |
| ![image](https://user-images.githubusercontent.com/10660608/66694365-6c0ba580-ec67-11e9-90ca-cb0693ba2e6c.png) | ![image](https://user-images.githubusercontent.com/10660608/66694384-86458380-ec67-11e9-834d-a32311185708.png) |

### With capacity

| No accepted users | With accepted users |
| - | - |
| ![image](https://user-images.githubusercontent.com/10660608/66694412-d4f31d80-ec67-11e9-903b-c96514b3e0ae.png) | ![image](https://user-images.githubusercontent.com/10660608/66694414-dd4b5880-ec67-11e9-8564-3c8e741c7a6b.png) |



