### PR TITLE
Refactor event details to EventSummary entity

### DIFF
--- a/apollo/entities/__init__.py
+++ b/apollo/entities/__init__.py
@@ -1,0 +1,1 @@
+from .event_summary import EventSummary

--- a/apollo/entities/event_summary.py
+++ b/apollo/entities/event_summary.py
@@ -1,0 +1,60 @@
+class EventSummary:
+    """
+    This entity serves as a way to flesh out all of the details of an Apollo event
+    that require us to interact with the Discord API (allowing us to keep the
+    underlying model separate from the Discord API).
+    """
+
+    def __init__(self, discord_guild, event, responses):
+        self.discord_guild = discord_guild
+        self.event = event
+        self.responses = responses
+
+    @property
+    def title(self):
+        return self.event.title
+
+    @property
+    def description(self):
+        return self.event.description
+
+    @property
+    def capacity(self):
+        return self.event.capacity
+
+    def start_time_display(self):
+        return self.event.start_time_string()
+
+    def organizer(self):
+        return self.discord_guild.get_member(self.event.organizer_id)
+
+    def accepted_members(self):
+        user_ids = self._user_ids_by_status(self.responses, "accepted")[: self.capacity]
+        return self._user_ids_to_members(user_ids, self.discord_guild)
+
+    def declined_members(self):
+        user_ids = self._user_ids_by_status(self.responses, "declined")
+        return self._user_ids_to_members(user_ids, self.discord_guild)
+
+    def tentative_members(self):
+        user_ids = self._user_ids_by_status(self.responses, "alternate")
+        return self._user_ids_to_members(user_ids, self.discord_guild)
+
+    def standby_members(self):
+        if not self.capacity:
+            return []
+        user_ids = self._user_ids_by_status(self.responses, "accepted")[self.capacity :]
+        return self._user_ids_to_members(user_ids, self.discord_guild)
+
+    def _user_ids_by_status(self, responses, status):
+        filtered_responses = list(filter(lambda r: r.status == status, responses))
+        filtered_responses.sort(key=lambda r: r.last_updated)
+        return list(map(lambda r: r.user_id, filtered_responses))
+
+    def _user_ids_to_members(self, user_ids, discord_guild):
+        members = []
+        for user_id in user_ids:
+            member = discord_guild.get_member(user_id)
+            if member:
+                members.append(member)
+        return members

--- a/apollo/services/list_event.py
+++ b/apollo/services/list_event.py
@@ -1,4 +1,5 @@
 from apollo import emojis as emoji
+from apollo.entities import EventSummary
 
 
 class ListEvent:
@@ -7,7 +8,9 @@ class ListEvent:
         self.event_embed = event_embed
 
     async def call(self, event, responses, discord_channel):
-        embed = self.event_embed.call(event, responses, discord_channel.guild)
+        event_summary = EventSummary(discord_channel.guild, event, responses)
+
+        embed = self.event_embed.call(event_summary)
         event_message = await discord_channel.send(embed=embed)
 
         # Update event message reference

--- a/apollo/services/update_event.py
+++ b/apollo/services/update_event.py
@@ -1,9 +1,13 @@
+from apollo.entities import EventSummary
+
+
 class UpdateEvent:
     def __init__(self, bot, event_embed):
         self.bot = bot
         self.event_embed = event_embed
 
     async def call(self, event, responses, discord_channel):
-        event_embed = self.event_embed.call(event, responses, discord_channel.guild)
+        event_summary = EventSummary(discord_channel.guild, event, responses)
+        event_embed = self.event_embed.call(event_summary)
         event_message = await discord_channel.fetch_message(event.message_id)
         await event_message.edit(embed=event_embed)


### PR DESCRIPTION
There's quite a bit of additional information we need to build from our
Event model before we can display it. Much of this work involves
reaching out to Discord's API to get information about Discord users who
have RSVP'd to the event.

Currently this logic lives almost entirely inside our event embed
service. This isn't great, as if we ever need to access this information
in a different context, we've no choice but to copy paste.

To solve this, we can extract all of our "extra" information about an
event model to a standalone entity, allowing us to reuse this code
wherever we please.